### PR TITLE
Show art in image element instead of canvas and add fade animation

### DIFF
--- a/source/elements/cover.js
+++ b/source/elements/cover.js
@@ -4,24 +4,16 @@ import {buildComposite} from '../utilities/composite';
 
 import podcastSvg from '../../assets/podcast.svg';
 
-function vector(x, y) {
-  return {x, y};
-}
+const fadeInDurationMs = 350;
 
 const OctopodCoverElement = function (BaseElement, composite) {
   return class extends BaseElement {
-    #coverImageUrl = null;
     #currentImageUrl = null;
     #imageCache = {};
 
     #shadowDom = null;
 
-    #canvas = null;
-    #canvasContext = null;
-    #resizeObserver = null;
-
     #chapterUpdateListener = null;
-    #windowFocusListener = null;
 
     static get observedAttributes() {
       return [
@@ -36,30 +28,13 @@ const OctopodCoverElement = function (BaseElement, composite) {
       this.#shadowDom = this.attachShadow({mode: 'closed'});
 
       this.#chapterUpdateListener = () => this.#redraw();
-      this.#windowFocusListener = this.#windowFocusCallback.bind(this);
 
       composite.addConnectedCallback(() => {
-        this.#canvas = document.createElement('canvas');
-        this.#canvasContext = this.#canvas.getContext('2d');
-
-        this.#resizeObserver = new ResizeObserver(() => this.#resize());
-        this.#resizeObserver.observe(this);
-
         this.#renderShadowDom();
-
-        window.addEventListener('focus', this.#windowFocusListener);
-      });
-
-      composite.addDisconnectedCallback(() => {
-        window.removeEventListener('focus', this.#windowFocusListener);
       });
 
       composite.addAttributeChangedCallback('image', (oldValue, newValue) => {
-        this.#coverImageUrl = newValue;
-
-        if (this.#canvas) {
-          this.#redraw();
-        }
+        this.#redraw();
       });
 
       this.addEventListener('chapterupdate', this.#chapterUpdateListener);
@@ -100,8 +75,6 @@ const OctopodCoverElement = function (BaseElement, composite) {
         return;
       }
 
-      this.#showPlaceholder();
-
       this.#currentImageUrl = src;
 
       this.#loadImage(src).then(image => {
@@ -112,46 +85,20 @@ const OctopodCoverElement = function (BaseElement, composite) {
     }
 
     #doDrawImage(image) {
-      const rect = this.getBoundingClientRect();
+      const imageElement = document.createElement("img");
+      imageElement.src = image.src;
 
-      const canvasSize = vector(rect.width, rect.height);
-      const sourceSize = vector(image.width, image.height);
+      const oldImagesToRemove = [
+        ...this.#shadowDom.querySelectorAll(".images img"),
+      ];
 
-      const destination = vector(0, 0);
-      const size = {...canvasSize};
+      // Add new image
+      this.#shadowDom.querySelector(".images").appendChild(imageElement);
 
-      const ratio = sourceSize.x / sourceSize.y;
-      const targetWidth = canvasSize.y * ratio;
-
-      if (canvasSize.x >= targetWidth) {
-        // Resized image fits width of container
-        size.x = targetWidth;
-        destination.x = canvasSize.x / 2 - size.x / 2;
-      } else {
-        // Resized image doesn't fit width of container
-        size.y = canvasSize.x / ratio;
-        destination.y = canvasSize.y / 2 - size.y / 2;
-      }
-
-      this.#hidePlaceholder();
-
-      this.#canvasContext.clearRect(0, 0, canvasSize.x, canvasSize.y);
-
-      this.#canvasContext.drawImage(
-        image,
-        0, 0, sourceSize.x, sourceSize.y,
-        destination.x, destination.y, size.x, size.y
-      );
-    }
-
-    #hidePlaceholder() {
-      this.#shadowDom.querySelector('.placeholder').classList.add('hide');
-    }
-
-    #showPlaceholder() {
-      this.#canvasContext.clearRect(0, 0, this.#canvas.width, this.#canvas.height);
-
-      this.#shadowDom.querySelector('.placeholder').classList.remove('hide');
+      setTimeout(() => {
+        // Remove any images that aren't at the front
+        oldImagesToRemove.forEach((oldImage) => oldImage.remove());
+      }, fadeInDurationMs);
     }
 
     #redraw(force = false) {
@@ -161,63 +108,14 @@ const OctopodCoverElement = function (BaseElement, composite) {
         this.#drawImage(chapter.img, force);
       } else if (this.imageUrl) {
         this.#drawImage(this.imageUrl, force);
-      } else {
-        this.#showPlaceholder();
       }
-    }
-
-    #resize() {
-      const container = this.#shadowDom.querySelector('.container');
-      const placeholder = this.#shadowDom.querySelector('.placeholder');
-
-      const setSizes = (width, height) => {
-        this.#canvas.width = width;
-        this.#canvas.height = height;
-
-        const placeholderSize = Math.min(width, height);
-
-        placeholder.style.width = placeholderSize === 0 ? '0' : placeholderSize + 'px';
-        placeholder.style.height = placeholderSize === 0 ? '0' : placeholderSize + 'px';
-        placeholder.style.top = null;
-        placeholder.style.left = null;
-
-        if (height > width) {
-          placeholder.style.top = ((height - width) / 2) + 'px';
-        } else if (height < width) {
-          placeholder.style.left = ((width - height) / 2) + 'px';
-        }
-      };
-
-      container.style.height = null;
-      setSizes(0, 0);
-
-      const width = +window.getComputedStyle(this).width.replace('px', '');
-      let height = +window.getComputedStyle(this).height.replace('px', '');
-
-      if (height === 0) {
-        height = width;
-
-        container.style.height = width + 'px';
-      }
-
-      setSizes(width, height);
-
-      this.#redraw();
     }
 
     #renderShadowDom() {
       this.#shadowDom.innerHTML = coverDom;
-
-      this.#shadowDom.querySelector('.container').appendChild(this.#canvas);
-
-      this.#resize();
+      this.#redraw();
     }
 
-    #windowFocusCallback() {
-      // This should draw the image if the canvas was created when the window was out of focus. Sadly, Chromium browsers
-      // still don't always render the changes to the canvas after gaining focus on the page for the first time.
-      this.#redraw(true);
-    }
   };
 };
 
@@ -227,41 +125,75 @@ const coverDom = `
       position: relative;
       display: block;
       overflow: hidden;
-      width: 360px;
       background: #f1f3f4;
+      margin: 0 auto;
     }
 
-    .container, .reference {
+    .container {
       position: relative;
       width: 100%;
       height: 100%;
     }
 
-    .reference {
-      z-index: -1;
+    .container .images {
+      z-index: 2;
+      position: relative;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    
+    .container .images:after {
+      /* Keeps .images always in a square aspect ratio */
+      content: "";
+      display: block;
+      padding-bottom: 100%;
     }
 
-    .placeholder, canvas {
+    .container .images img {
+      object-fit: contain;
+      width: 100%;
+      max-height: 100%;
+      position: absolute;
+      left: 0;
+      right: 0;
+      animation: fadeIn ${fadeInDurationMs}ms;
+    }
+
+    @keyframes fadeIn {
+      0% {
+        opacity: 0;
+      }
+
+      100% {
+        opacity: 1;
+      }
+    }
+
+    .placeholder {
+      z-index: 1;
       position: absolute;
       top: 0;
       left: 0;
       right: 0;
       bottom: 0;
-      display: block;
       width: 100%;
       height: 100%;
-    }
-
-    .placeholder.hide {
-      display: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .placeholder svg {
-      margin: 25% 28%;
+      width: 50%;
+      height: 50%;
       color: #000000;
     }
   </style>
   <div class="container">
+    <div class="images"></div>
     <div class="placeholder">
       ${podcastSvg}
     </div>


### PR DESCRIPTION
- Resolve an issue where art disappears after the window is resized
- Resolve an issue where the art will sometimes not render if the page loads in the background and not in the foreground
- Simplify cover display logic and improve performance by moving positioning to CSS
- Add a fade animation when new cover art appears

# Page resize before/after
https://user-images.githubusercontent.com/3038600/111952829-b2e40880-8ab3-11eb-825c-bf7afc1b32c4.mov

https://user-images.githubusercontent.com/3038600/111952840-b5def900-8ab3-11eb-9abd-fdd2863a2ef3.mov

# Container `:host` resizing before/after
https://user-images.githubusercontent.com/3038600/111952494-3ea96500-8ab3-11eb-8b83-7f7bb905b898.mov

https://user-images.githubusercontent.com/3038600/111952513-45d07300-8ab3-11eb-8822-5b4c33d8ef35.mov








